### PR TITLE
BasicComponent.updateClasses: check dom node exists

### DIFF
--- a/bindings/react/src/components/BasicComponent.jsx
+++ b/bindings/react/src/components/BasicComponent.jsx
@@ -11,7 +11,9 @@ class BasicComponent extends React.Component {
 
   updateClasses() {
     var node = ReactDOM.findDOMNode(this);
-
+    
+    if (!node) return;
+        
     if (typeof this.props.className !== 'undefined') {
       if (this.lastClass) {
         node.className = node.className.replace(this.lastClass, ' ');


### PR DESCRIPTION
using mobx and inferno, there are cases where a component has unmounted before updateClasses is called, which throws a multitude of errors. A simple check and early return fixes this issue.